### PR TITLE
Bump dependencies

### DIFF
--- a/com.ghostery.browser.yml
+++ b/com.ghostery.browser.yml
@@ -33,7 +33,7 @@ finish-args:
 - "--env=MOZ_USE_XINPUT2=1"
 - "--own-name=org.mpris.MediaPlayer2.firefox.*"
 modules:
-- shared-modules/dbus-glib/dbus-glib-0.110.json
+- shared-modules/dbus-glib/dbus-glib.json
 - name: gtk-cups-backend
   buildsystem: meson
   make-args:

--- a/com.ghostery.browser.yml
+++ b/com.ghostery.browser.yml
@@ -63,9 +63,9 @@ modules:
   - "-Dgtk_doc=false"
   - "-Ddocbook_docs=disabled"
   sources:
-  - sha256: c5f4ed3d1f86e5b118c76415aacb861873ed3e6f0c6b3181b828cf584fc5c616
+  - sha256: ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0
     type: archive
-    url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.2.tar.xz
+    url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.3.tar.xz
     x-checker-data:
       project-id: 13149
       type: anitya

--- a/com.ghostery.browser.yml
+++ b/com.ghostery.browser.yml
@@ -1,3 +1,4 @@
+%YAML 1.1
 ---
 app-id: com.ghostery.browser
 runtime: org.freedesktop.Platform


### PR DESCRIPTION
- Closes #8 
- Try to use last version of D-BUS
- Instruct flathub yaml parser about the ruby parser version