### PR TITLE
Fixed typo in the release year

### DIFF
--- a/com.ghostery.browser.metainfo.xml
+++ b/com.ghostery.browser.metainfo.xml
@@ -20,7 +20,7 @@
     <p>This browser is currently only available in english.</p>
   </description>
   <releases>
-    <release version="2024.02" date="2023-03-01">
+    <release version="2024.02" date="2024-03-01">
       <description>
         <ul>
           <li>Completey new New Tab Page</li>


### PR DESCRIPTION
Last build is from 2024-03-01, not 2023-03-01