### PR TITLE
2024.03

### DIFF
--- a/com.ghostery.browser.metainfo.xml
+++ b/com.ghostery.browser.metainfo.xml
@@ -20,6 +20,15 @@
     <p>This browser is currently only available in english.</p>
   </description>
   <releases>
+    <release version="2024.03" date="2024-03-06">
+      <description>
+        <ul>
+          <li>Fix German and French language version that broke in 2024-02</li>
+          <li>Merge with Firefox 123</li>
+          <li>Update of Ghostery extension to version 10.2.13</li>
+        </ul>
+      </description>
+    </release>
     <release version="2024.02" date="2024-03-01">
       <description>
         <ul>

--- a/com.ghostery.browser.yml
+++ b/com.ghostery.browser.yml
@@ -33,7 +33,7 @@ finish-args:
 - "--env=MOZ_USE_XINPUT2=1"
 - "--own-name=org.mpris.MediaPlayer2.firefox.*"
 modules:
-- shared-modules/dbus-glib/dbus-glib-0.110.json
+- shared-modules/dbus-glib/dbus-glib.json
 - name: gtk-cups-backend
   buildsystem: meson
   make-args:

--- a/com.ghostery.browser.yml
+++ b/com.ghostery.browser.yml
@@ -85,8 +85,8 @@ modules:
   - install -d /app/lib/ffmpeg
   sources:
   - type: archive
-    url: https://github.com/ghostery/user-agent-desktop/releases/download/2024-03-01/Ghostery-2024.02.en-US.linux.tar.gz
-    sha256: 256a6e0888796ff4beee042e1de691337c49109c4106869bfee3a99b3138e22e
+    url: https://github.com/ghostery/user-agent-desktop/releases/download/2024-03-06/Ghostery-2024.03.en-US.linux.tar.gz
+    sha256: 989123c5e8704bbf011746a5e70c989be9667654b2282bc4e6031cb019174dd4
     dest: ghostery_app
     strip-components: 0
   - type: file

--- a/com.ghostery.browser.yml
+++ b/com.ghostery.browser.yml
@@ -63,9 +63,9 @@ modules:
   - "-Dgtk_doc=false"
   - "-Ddocbook_docs=disabled"
   sources:
-  - sha256: c5f4ed3d1f86e5b118c76415aacb861873ed3e6f0c6b3181b828cf584fc5c616
+  - sha256: ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0
     type: archive
-    url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.2.tar.xz
+    url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.3.tar.xz
     x-checker-data:
       project-id: 13149
       type: anitya

--- a/com.ghostery.browser.yml
+++ b/com.ghostery.browser.yml
@@ -1,3 +1,4 @@
+%YAML 1.1
 ---
 app-id: com.ghostery.browser
 runtime: org.freedesktop.Platform


### PR DESCRIPTION
Update to https://github.com/ghostery/user-agent-desktop/releases/tag/2024-03-06

Also, it includes the changes from https://github.com/flathub/com.ghostery.browser/pull/13