### PR TITLE
Bump to 2024.8.1

### DIFF
--- a/com.ghostery.browser.metainfo.xml
+++ b/com.ghostery.browser.metainfo.xml
@@ -20,6 +20,14 @@
     <p>This browser is currently only available in english.</p>
   </description>
   <releases>
+    <release version="2024.8.1" date="2024-09-03">
+      <description>
+        <ul>
+          <li>Merge with Firefox 129.0.2</li>
+          <li>Update of Ghostery extension to version 10.4.3</li>
+        </ul>
+      </description>
+    </release>
     <release version="2024.8" date="2024-08-09">
       <description>
         <ul>

--- a/com.ghostery.browser.yml
+++ b/com.ghostery.browser.yml
@@ -85,8 +85,8 @@ modules:
   - install -d /app/lib/ffmpeg
   sources:
   - type: archive
-    url: https://github.com/ghostery/user-agent-desktop/releases/download/2024-08-09/Ghostery-2024.8.en-US.linux.tar.gz
-    sha256: c12f2c80857a2cd7ca46527f7d7a681d8e125f3f1fed5fc006bfa3ea54870fd8
+    url: https://github.com/ghostery/user-agent-desktop/releases/download/2024-08-30/Ghostery-2024.8.1.en-US.linux.tar.gz
+    sha256: 92f8b2d2a969efa8780436e07c45c1eb07229a5bc7cb0cfa3e4c9eb66dd19399
     dest: ghostery_app
     strip-components: 0
   - type: file


### PR DESCRIPTION
https://github.com/ghostery/user-agent-desktop/releases/tag/2024-08-30